### PR TITLE
fix: Update OpenAIApi.cs for chunks incomplete bug

### DIFF
--- a/Runtime/OpenAIApi.cs
+++ b/Runtime/OpenAIApi.cs
@@ -112,8 +112,8 @@ namespace OpenAI
                 request.method = method;
                 request.SetHeaders(Configuration, ContentType.ApplicationJson);
                 
-                var asyncOperation = request.SendWebRequest();
-
+                request.SendWebRequest();
+                bool isDone = false;
                 do
                 {
                     List<T> dataList = new List<T>();
@@ -122,10 +122,9 @@ namespace OpenAI
                     foreach (string line in lines)
                     {
                         var value = line.Replace("data: ", "");
-                        
-                        if (value.Contains("[DONE]")) 
+                        if (value.Contains("stop")) 
                         {
-                            onComplete?.Invoke();
+                            isDone = true;
                             break;
                         }
                         
@@ -145,7 +144,7 @@ namespace OpenAI
                     
                     await Task.Yield();
                 }
-                while (!asyncOperation.isDone && !token.IsCancellationRequested);
+                while (!isDone);
                 
                 onComplete?.Invoke();
             }


### PR DESCRIPTION
when I received the messages by stream or chunks sometimes I received the last message incomplete, the reason was that the request.isDone() was set to false and finished receiving messages before receiving the message of finisih_reason of the OpenAI API, then I modified the logic so that it only closes the cycle when I get the stop in finish_reason that is the flag that warns me that it finished sending me chunks.