### PR TITLE
Support JSON response: CreateChatCompletionRequest class supports response_format field

### DIFF
--- a/Runtime/OpenAIApi.cs
+++ b/Runtime/OpenAIApi.cs
@@ -35,11 +35,18 @@ namespace OpenAI
             }
         }
 
+        private const string OFFICIAL_BASE_PATH = "https://api.openai.com/v1";
+        
         /// OpenAI API base path for requests.
-        private const string BASE_PATH = "https://api.openai.com/v1";
-
-        public OpenAIApi(string apiKey = null, string organization = null)
+        private readonly string _basePath;
+        
+        public OpenAIApi(string apiKey = null, string organization = null, string baseUrl = null)
         {
+            if (string.IsNullOrEmpty(baseUrl))
+                _basePath = OFFICIAL_BASE_PATH;
+            else 
+                _basePath = baseUrl;
+            
             if (apiKey != null)
             {
                 configuration = new Configuration(apiKey, organization);
@@ -202,7 +209,7 @@ namespace OpenAI
         /// </summary>
         public async Task<ListModelsResponse> ListModels()
         {
-            var path = $"{BASE_PATH}/models";
+            var path = $"{_basePath}/models";
             return await DispatchRequest<ListModelsResponse>(path, UnityWebRequest.kHttpVerbGET);
         }
         
@@ -213,7 +220,7 @@ namespace OpenAI
         /// <returns>See <see cref="Model"/></returns>
         public async Task<OpenAIModel> RetrieveModel(string id)
         {
-            var path = $"{BASE_PATH}/models/{id}";
+            var path = $"{_basePath}/models/{id}";
             return await DispatchRequest<OpenAIModelResponse>(path, UnityWebRequest.kHttpVerbGET);
         }
 
@@ -224,9 +231,8 @@ namespace OpenAI
         /// <returns>See <see cref="CreateChatCompletionResponse"/></returns>
         public async Task<CreateChatCompletionResponse> CreateChatCompletion(CreateChatCompletionRequest request)
         {
-            var path = $"{BASE_PATH}/chat/completions";
+            var path = $"{_basePath}/chat/completions";
             var payload = CreatePayload(request);
-            
             return await DispatchRequest<CreateChatCompletionResponse>(path, UnityWebRequest.kHttpVerbPOST, payload);
         }
         
@@ -240,7 +246,7 @@ namespace OpenAI
         public void CreateChatCompletionAsync(CreateChatCompletionRequest request, Action<List<CreateChatCompletionResponse>> onResponse, Action onComplete, CancellationTokenSource token)
         {
             request.Stream = true;
-            var path = $"{BASE_PATH}/chat/completions";
+            var path = $"{_basePath}/chat/completions";
             var payload = CreatePayload(request);
             
             DispatchRequest(path, UnityWebRequest.kHttpVerbPOST, onResponse, onComplete, token, payload);
@@ -253,7 +259,7 @@ namespace OpenAI
         /// <returns>See <see cref="CreateImageResponse"/></returns>
         public async Task<CreateImageResponse> CreateImage(CreateImageRequest request)
         {
-            var path = $"{BASE_PATH}/images/generations";
+            var path = $"{_basePath}/images/generations";
             var payload = CreatePayload(request);
             return await DispatchRequest<CreateImageResponse>(path, UnityWebRequest.kHttpVerbPOST, payload);
         }
@@ -265,7 +271,7 @@ namespace OpenAI
         /// <returns>See <see cref="CreateImageResponse"/></returns>
         public async Task<CreateImageResponse> CreateImageEdit(CreateImageEditRequest request)
         {
-            var path = $"{BASE_PATH}/images/edits";
+            var path = $"{_basePath}/images/edits";
 
             var form = new List<IMultipartFormSection>();
             form.AddFile(request.Image, "image", "image/png");
@@ -285,7 +291,7 @@ namespace OpenAI
         /// <returns>See <see cref="CreateImageResponse"/></returns>
         public async Task<CreateImageResponse> CreateImageVariation(CreateImageVariationRequest request)
         {
-            var path = $"{BASE_PATH}/images/variations";
+            var path = $"{_basePath}/images/variations";
             
             var form = new List<IMultipartFormSection>();
             form.AddFile(request.Image, "image", "image/png");
@@ -304,7 +310,7 @@ namespace OpenAI
         /// <returns>See <see cref="CreateEmbeddingsResponse"/></returns>
         public async Task<CreateEmbeddingsResponse> CreateEmbeddings(CreateEmbeddingsRequest request)
         {
-            var path = $"{BASE_PATH}/embeddings";
+            var path = $"{_basePath}/embeddings";
             var payload = CreatePayload(request);
             return await DispatchRequest<CreateEmbeddingsResponse>(path, UnityWebRequest.kHttpVerbPOST, payload);
         }
@@ -316,7 +322,7 @@ namespace OpenAI
         /// <returns>See <see cref="CreateAudioResponse"/></returns>
         public async Task<CreateAudioResponse> CreateAudioTranscription(CreateAudioTranscriptionsRequest request)
         {
-            var path = $"{BASE_PATH}/audio/transcriptions";
+            var path = $"{_basePath}/audio/transcriptions";
             
             var form = new List<IMultipartFormSection>();
             if (string.IsNullOrEmpty(request.File))
@@ -343,7 +349,7 @@ namespace OpenAI
         /// <returns>See <see cref="CreateAudioResponse"/></returns>
         public async Task<CreateAudioResponse> CreateAudioTranslation(CreateAudioTranslationRequest request)
         {
-            var path = $"{BASE_PATH}/audio/translations";
+            var path = $"{_basePath}/audio/translations";
             
             var form = new List<IMultipartFormSection>();
             if (string.IsNullOrEmpty(request.File))
@@ -368,7 +374,7 @@ namespace OpenAI
         /// <returns>See <see cref="ListFilesResponse"/></returns>
         public async Task<ListFilesResponse> ListFiles()
         {
-            var path = $"{BASE_PATH}/files";
+            var path = $"{_basePath}/files";
             return await DispatchRequest<ListFilesResponse>(path, UnityWebRequest.kHttpVerbGET);
         }
         
@@ -381,7 +387,7 @@ namespace OpenAI
         /// <returns>See <see cref="OpenAIFile"/></returns>
         public async Task<OpenAIFile> CreateFile(CreateFileRequest request)
         {
-            var path = $"{BASE_PATH}/files";
+            var path = $"{_basePath}/files";
             
             var form = new List<IMultipartFormSection>();
             form.AddFile(request.File, "file", "application/json");
@@ -397,7 +403,7 @@ namespace OpenAI
         /// <returns>See <see cref="DeleteResponse"/></returns>
         public async Task<DeleteResponse> DeleteFile(string id)
         {
-            var path = $"{BASE_PATH}/files/{id}";
+            var path = $"{_basePath}/files/{id}";
             return await DispatchRequest<DeleteResponse>(path, UnityWebRequest.kHttpVerbDELETE);
         }
         
@@ -408,7 +414,7 @@ namespace OpenAI
         /// <returns>See <see cref="OpenAIFile"/></returns>
         public async Task<OpenAIFile> RetrieveFile(string id)
         {
-            var path = $"{BASE_PATH}/files/{id}";
+            var path = $"{_basePath}/files/{id}";
             return await DispatchRequest<OpenAIFileResponse>(path, UnityWebRequest.kHttpVerbGET);
         }
         
@@ -419,7 +425,7 @@ namespace OpenAI
         /// <returns>See <see cref="OpenAIFile"/></returns>
         public async Task<OpenAIFile> DownloadFile(string id)
         {
-            var path = $"{BASE_PATH}/files/{id}/content";
+            var path = $"{_basePath}/files/{id}/content";
             return await DispatchRequest<OpenAIFileResponse>(path, UnityWebRequest.kHttpVerbGET);
         }
         
@@ -431,7 +437,7 @@ namespace OpenAI
         /// <returns>See <see cref="FineTune"/></returns>
         public async Task<FineTune> CreateFineTune(CreateFineTuneRequest request)
         {
-            var path = $"{BASE_PATH}/fine-tunes";
+            var path = $"{_basePath}/fine-tunes";
             var payload = CreatePayload(request);
             return await DispatchRequest<FineTuneResponse>(path, UnityWebRequest.kHttpVerbPOST, payload);
         }
@@ -442,7 +448,7 @@ namespace OpenAI
         /// <returns>See <see cref="ListFineTunesResponse"/></returns>
         public async Task<ListFineTunesResponse> ListFineTunes()
         {
-            var path = $"{BASE_PATH}/fine-tunes";
+            var path = $"{_basePath}/fine-tunes";
             return await DispatchRequest<ListFineTunesResponse>(path, UnityWebRequest.kHttpVerbGET);
         }
         
@@ -453,7 +459,7 @@ namespace OpenAI
         /// <returns>See <see cref="FineTune"/></returns>
         public async Task<FineTune> RetrieveFineTune(string id)
         {
-            var path = $"{BASE_PATH}/fine-tunes/{id}";
+            var path = $"{_basePath}/fine-tunes/{id}";
             return await DispatchRequest<FineTuneResponse>(path, UnityWebRequest.kHttpVerbGET);
         }
         
@@ -464,7 +470,7 @@ namespace OpenAI
         /// <returns>See <see cref="FineTune"/></returns>
         public async Task<FineTune> CancelFineTune(string id)
         {
-            var path = $"{BASE_PATH}/fine-tunes/{id}/cancel";
+            var path = $"{_basePath}/fine-tunes/{id}/cancel";
             return await DispatchRequest<FineTuneResponse>(path, UnityWebRequest.kHttpVerbPOST);
         }
         
@@ -479,7 +485,7 @@ namespace OpenAI
         /// <returns>See <see cref="ListFineTuneEventsResponse"/></returns>
         public async Task<ListFineTuneEventsResponse> ListFineTuneEvents(string id, bool stream = false)
         {
-            var path = $"{BASE_PATH}/fine-tunes/{id}/events?stream={stream}";
+            var path = $"{_basePath}/fine-tunes/{id}/events?stream={stream}";
             return await DispatchRequest<ListFineTuneEventsResponse>(path, UnityWebRequest.kHttpVerbGET);
         }
         
@@ -490,7 +496,7 @@ namespace OpenAI
         /// <returns>See <see cref="DeleteResponse"/></returns>
         public async Task<DeleteResponse> DeleteFineTunedModel(string model)
         {
-            var path = $"{BASE_PATH}/models/{model}";
+            var path = $"{_basePath}/models/{model}";
             return await DispatchRequest<DeleteResponse>(path, UnityWebRequest.kHttpVerbDELETE);
         }
 
@@ -501,7 +507,7 @@ namespace OpenAI
         /// <returns>See <see cref="CreateModerationResponse"/></returns>
         public async Task<CreateModerationResponse> CreateModeration(CreateModerationRequest request)
         {
-            var path = $"{BASE_PATH}/moderations";
+            var path = $"{_basePath}/moderations";
             var payload = CreatePayload(request);
             return await DispatchRequest<CreateModerationResponse>(path, UnityWebRequest.kHttpVerbPOST, payload);
         }


### PR DESCRIPTION
Supports specifying the response return format, either JSON or text.  Address [#105](https://github.com/srcnalt/OpenAI-Unity/issues/105)

See
[OpenAI API document of response_format parameter](https://platform.openai.com/docs/api-reference/chat/create#chat-create-response_format)
GPT-4-turbo and GPT-3.5-turbo-1106 support this parameter. 

Specifying the return result as JSON is useful for workflows.

Code sample:
```
                _task = _openAi.CreateChatCompletion(new CreateChatCompletionRequest()
                {
                    Model = "gpt-3.5-turbo",
                    Messages = new List<ChatMessage>()
                    {
                        new() {Role = "system", Content = "Output JSON"},
                        new() {Role = "user", Content = "What's US and China's population?"}
                    },
                    ResponseFormat = ResponseFormat.JsonObject
                });
```

Response:

```
{
    "country_populations": {
        "United States": "331.9 million",
        "China": "1.41 billion"
    }
}
```

If you removed the  `ResponseFormat = ResponseFormat.JsonObject`, the response becomes:

```
As of September 2021, the population of the United States is approximately 331 million and the population of China is approximately 1.4 billion.
```

**Note**: According to the document, when using JSON mode, you **must** also instruct the model to produce JSON yourself via a system or user message. 
