### PR TITLE
FIX: request done before all chunks are received

### DIFF
--- a/Runtime/OpenAIApi.cs
+++ b/Runtime/OpenAIApi.cs
@@ -112,6 +112,7 @@ namespace OpenAI
                 request.SetHeaders(Configuration, ContentType.ApplicationJson);
                 
                 var asyncOperation = request.SendWebRequest();
+                bool isDone = false;
 
                 do
                 {
@@ -124,6 +125,7 @@ namespace OpenAI
                         
                         if (value.Contains("[DONE]")) 
                         {
+                            isDone = true;
                             onComplete?.Invoke();
                             break;
                         }
@@ -144,7 +146,7 @@ namespace OpenAI
                     
                     await Task.Yield();
                 }
-                while (!asyncOperation.isDone && !token.IsCancellationRequested);
+                while (!isDone);
                 
                 onComplete?.Invoke();
             }


### PR DESCRIPTION
The request on `CreateChatCompletionAsync` is complete before all the text is received. I think OpenAi changed something on the API.